### PR TITLE
Amélioration des sockets.

### DIFF
--- a/Shared/CMakeLists.txt
+++ b/Shared/CMakeLists.txt
@@ -28,7 +28,7 @@ set(SHARED_SOURCE_FILES
         Include/Socket/IRTypeSocket.hpp
         Include/Socket/RTypeNetworkPayload.h
         Include/Socket/Enum/RTypeSocketType.h
-        Include/Socket/Linux/RTypeSocket.hpp
+        Include/Socket/UNIX/RTypeSocket.hpp
         Include/Socket/Windows/RTypeSocket.hpp
 
         Include/Time/Timer.hpp
@@ -43,20 +43,17 @@ include_directories(Libs/Interfaces
         Include/
         ../SFML/include
         LibraryLoader
-        Socket/
-        Socket/Interfaces
         Include/Socket/Enum
+        Include/Socket
         ../SharedLibs/Interfaces)
 
 IF (MSVC)
-    set(LIBRARY_SOCKET_FILES Include/Socket/Windows/RTypeSocket.hpp)
     set(LIB_SOCKET ws2_32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 ELSE()
-    set(LIBRARY_SOCKET_FILES Include/Socket/Linux/RTypeSocket.hpp)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror -Wuninitialized -Winit-self -Wno-unused-parameter -Wno-unused-private-field")
 ENDIF()
 
-add_library(RTypeShared STATIC ${SHARED_SOURCE_FILES} ${LIBRARY_SOCKET_FILES})
+add_library(RTypeShared STATIC ${SHARED_SOURCE_FILES})
 
 target_link_libraries(RTypeShared LibraryLoader ${LIB_SOCKET})

--- a/Shared/Include/Socket/IRTypeSocket.hpp
+++ b/Shared/Include/Socket/IRTypeSocket.hpp
@@ -20,9 +20,9 @@ public:
 
     virtual std::unique_ptr<IRTypeSocket> Accept() = 0;
 
-    virtual bool Receive(RTypeNetworkPayload &, size_t) = 0;
+    virtual bool Receive(RTypeNetworkPayload &) = 0;
 
-    virtual void Send(const std::string &payload) = 0;
+    virtual bool Send(const RTypeNetworkPayload &payload) = 0;
 };
 
 #endif //R_TYPE_IRTYPESOCKET_HPP

--- a/Shared/Include/Socket/RTypeNetworkPayload.h
+++ b/Shared/Include/Socket/RTypeNetworkPayload.h
@@ -9,10 +9,11 @@
 
 class RTypeNetworkPayload {
 public:
-    std::string Ip;
-    std::string Payload;
+    std::string Ip = "";
+    char *Payload;
+    int Length;
 
-    RTypeNetworkPayload(std::string const &ip = "", std::string const &payload = "") : Ip(ip), Payload(payload) {};
+    RTypeNetworkPayload(char *payload, int length) : Payload(payload), Length(length) {};
 };
 
 #endif //R_TYPE_RTYPENETWORKPAYLOAD_H

--- a/Shared/Include/Socket/UNIX/RTypeSocket.hpp
+++ b/Shared/Include/Socket/UNIX/RTypeSocket.hpp
@@ -171,7 +171,6 @@ public:
         socklen_t length = sizeof(clientAddr);
         int client = accept(_socket, (struct sockaddr *) &clientAddr, &length);
         if (client < 0) {
-            std::cerr << "Server Accept Failed !" << std::endl;
             return nullptr;
         }
         return std::unique_ptr<IRTypeSocket>(new RTypeSocket<TCP>(client, clientAddr));

--- a/Shared/Include/Socket/Windows/RTypeSocket.hpp
+++ b/Shared/Include/Socket/Windows/RTypeSocket.hpp
@@ -7,11 +7,11 @@
 
 #include <Socket/IRTypeSocket.hpp>
 #include <fcntl.h>
-#include <stdlib.h>
-#include <malloc.h>
+#include <cstdlib>
 #include <winsock.h>
 #include <stdexcept>
 #include <Socket/RTypeNetworkPayload.h>
+#include <Socket/Enum/RTypeSocketType.h>
 
 template<SocketType type>
 class RTypeSocket : public IRTypeSocket {
@@ -77,27 +77,22 @@ public:
         return nullptr;
     }
 
-    bool Receive(RTypeNetworkPayload &payload, size_t length) override final {
+    bool Receive(RTypeNetworkPayload &payload) override final {
         SOCKADDR_IN  clientAddr;
         int lengthSockAddr = sizeof(clientAddr);
 
-        char *buffer = (char *) malloc(sizeof(char) * length);
-        memset((buffer), '\0', (length));
-        SSIZE_T data = recvfrom(_socket, buffer, length, 0, (struct sockaddr *) &clientAddr, &lengthSockAddr);
+        memset((payload.Payload), '\0', (size_t) (payload.Length));
+        SSIZE_T data = recvfrom(_socket, payload.Payload, payload.Length, 0, (struct sockaddr *) &clientAddr, &lengthSockAddr);
         if (data == -1) {
-            free(buffer);
             return false;
         } else {
-            buffer[data] = '\0';
             payload.Ip = std::string(inet_ntoa(clientAddr.sin_addr));
-            payload.Payload = std::string(buffer);
-            free(buffer);
             return true;
         }
     }
 
-    bool Send(const std::string &payload) override final {
-        return !(sendto(_socket, payload.c_str(), payload.size(), 0, (struct sockaddr *) &_addr, sizeof(_addr)) < 0);
+    bool Send(const RTypeNetworkPayload &payload) override final {
+        return sendto(_socket, payload.Payload, payload.Length, 0, (struct sockaddr *) &_addr, sizeof(_addr)) >= 0;
     }
 };
 
@@ -133,6 +128,8 @@ private:
         }
     }
 
+    RTypeSocket(SOCKET socket, SOCKADDR_IN addrClient) : _identity(), _socket(socket), _addrServer(), _addrClient(addrClient), _port() {}
+
 public:
     RTypeSocket(uint16_t port) : _identity(), _socket(), _addrServer(), _addrClient(), _port(port) {
         _identity = Server;
@@ -156,8 +153,6 @@ public:
         CreateSocket();
     }
 
-    RTypeSocket(SOCKET socket, SOCKADDR_IN addrClient) : _identity(), _socket(socket), _addrServer(), _addrClient(addrClient), _port() {}
-
     ~RTypeSocket() {
 		closesocket(_socket);
         WSACleanup();
@@ -179,42 +174,32 @@ public:
     }
 
     bool Connect() override final {
-        if (connect(_socket, (struct sockaddr *) &_addrServer, sizeof(_addrServer)) < 0) {
-            std::cerr << "Connect failed !" << std::endl;
-            return false;
-        }
-        return true;
+        return connect(_socket, (struct sockaddr *) &_addrServer, sizeof(_addrServer)) >= 0;
     }
 
     std::unique_ptr<IRTypeSocket> Accept() override final {
         struct sockaddr_in clientAddr;
         int length = sizeof(clientAddr);
-        int client = accept(_socket, (struct sockaddr *) &clientAddr, &length);
+        SOCKET client = accept(_socket, (struct sockaddr *) &clientAddr, &length);
         if (client < 0) {
-            std::cerr << "Server Accept Failed !" << std::endl;
             return nullptr;
         }
         return std::unique_ptr<IRTypeSocket>(new RTypeSocket<TCP>(client, clientAddr));
     }
 
-    bool Receive(RTypeNetworkPayload &payload, size_t length) override final {
-        char *buffer = (char *) malloc(sizeof(char) * length);
-        memset((buffer), '\0', (length));
-        SSIZE_T data = recv(_socket,buffer,length,0);
+    bool Receive(RTypeNetworkPayload &payload) override final {
+        memset((payload.Payload), '\0', (size_t) (payload.Length));
+        SSIZE_T data = recv(_socket, payload.Payload, payload.Length,0);
         if (data == -1) {
-            free(buffer);
             return false;
         } else {
-            buffer[data] = '\0';
             payload.Ip = std::string(inet_ntoa(_addrClient.sin_addr));
-            payload.Payload = std::string(buffer);
-            free(buffer);
             return true;
         }
     }
 
-    bool Send(const std::string &payload) override final {
-        return !(send(_socket, payload.c_str(), payload.size(), 0) < 0);
+    bool Send(const RTypeNetworkPayload &payload) override final {
+        return send(_socket, payload.Payload, payload.Length, 0) >= 0;
     }
 };
 

--- a/Shared/Include/Socket/Windows/RTypeSocket.hpp
+++ b/Shared/Include/Socket/Windows/RTypeSocket.hpp
@@ -96,11 +96,8 @@ public:
         }
     }
 
-    void Send(const std::string &payload) override final {
-        if (sendto(_socket, payload.c_str(), payload.size(), 0, (struct sockaddr *) &_addr, sizeof(_addr)) < 0) {
-            // On ne throw pas ici car si il n'y a pas de server qui tourne lorseque le client tente de Send la function sendto renvera -1
-            std::cerr << "Sending failed !" << std::endl;
-        }
+    bool Send(const std::string &payload) override final {
+        return !(sendto(_socket, payload.c_str(), payload.size(), 0, (struct sockaddr *) &_addr, sizeof(_addr)) < 0);
     }
 };
 
@@ -216,10 +213,8 @@ public:
         }
     }
 
-    void Send(const std::string &payload) override final {
-        if (send(_socket, payload.c_str(), payload.size(), 0) < 0) {
-            std::cerr << "Sending failed !" << std::endl;
-        }
+    bool Send(const std::string &payload) override final {
+        return !(send(_socket, payload.c_str(), payload.size(), 0) < 0);
     }
 };
 

--- a/Shared/UnitTests/CMakeLists.txt
+++ b/Shared/UnitTests/CMakeLists.txt
@@ -13,10 +13,10 @@ set(SHARED_TEST_FILES
 IF (MSVC)
     set(LIBRARY_SOCKET_HEADER_FOLDER ../Include/Socket/Windows)
 ELSE()
-    set(LIBRARY_SOCKET_HEADER_FOLDER ../Include/Socket/Linux)
+    set(LIBRARY_SOCKET_HEADER_FOLDER ../Include/Socket/UNIX)
 ENDIF()
 
-include_directories(../Include ../Libs/Interfaces ../Socket/Includes ../Socket/Interfaces ../Include/Socket/Enum ${LIBRARY_SOCKET_HEADER_FOLDER})
+include_directories(../Include ../Libs/Interfaces ../Include/Socket/ ../Include/Socket/Enum ${LIBRARY_SOCKET_HEADER_FOLDER})
 
 foreach (_file ${SHARED_TEST_FILES})
     get_filename_component(SHARED_TEST_FILES_ABS ${_file} REALPATH)


### PR DESCRIPTION
Etant donner que @glacecise a merge ma PR hier soir a ma place je n'ai pas pu faire ces modif sur la précédente PR.

Les fonctions Send et Receive prennent désormais toute les deux un RTypeNetworkPayload qui contient une taille et un char* et non plus une std::string.