### PR TITLE
Collisions entre projectiles et entités

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cmake   ; fi
 
 install:
-  - if [ "$CXX" == "g++" ] && [ "$TRAVIS_OS_NAME" != "osx" ]; then export CXX="g++-5" CC="gcc-5"; fi
+  - if [[ "$CXX" = "g++" ] && [ "$TRAVIS_OS_NAME" != "osx" ]]; then export CXX="g++-5" CC="gcc-5"; fi
 
 script:
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cmake   ; fi
 
 install:
-  - if [[ "$CXX" = "g++" ] && [ "$TRAVIS_OS_NAME" != "osx" ]]; then export CXX="g++-5" CC="gcc-5"; fi
+  - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then export CXX="g++-5" CC="gcc-5"; fi
 
 script:
   - mkdir build

--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -8,7 +8,7 @@ include_directories(Includes Interfaces)
 IF (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 ELSE()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror -Wuninitialized -Winit-self -Weffc++ -Wno-unused-parameter -Wno-unused-private-field")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror -Wuninitialized -Winit-self -Wno-unused-parameter -Wno-unused-private-field")
 ENDIF()
 
 include_directories(SYSTEM "../SFML/include/")

--- a/Client/Includes/ClientEntityPool.hpp
+++ b/Client/Includes/ClientEntityPool.hpp
@@ -18,7 +18,7 @@ public:
 public :
     virtual void Draw(sf::RenderTexture &, TextureBag &);
 
-    virtual void AddEntity(std::string const &entityName, uint16_t, vec2<float> const &initialPos, TimeRef const & = TimeRef()) override;
+    virtual void AddEntity(std::string const &entityName, uint16_t, vec2<float> const &initialPos, TimeRef const &, std::initializer_list<void *> * = nullptr) override;
 };
 
 

--- a/Client/Includes/ClientEntityPool.hpp
+++ b/Client/Includes/ClientEntityPool.hpp
@@ -18,7 +18,7 @@ public:
 public :
     virtual void Draw(sf::RenderTexture &, TextureBag &);
 
-    virtual void AddEntity(std::string const &entityName, vec2<float> const &initialPos, TimeRef const & = TimeRef()) override;
+    virtual void AddEntity(std::string const &entityName, uint16_t, vec2<float> const &initialPos, TimeRef const & = TimeRef()) override;
 };
 
 

--- a/Client/sprites/testPartition.partition
+++ b/Client/sprites/testPartition.partition
@@ -14,7 +14,7 @@
 			"entityName":"DummyMonster",
 			"startPosition": {
 				"x":0,
-				"y":0
+				"y":400
 			},
 			"startTime":0,
 			"id":1
@@ -22,8 +22,8 @@
 		{
 			"entityName":"DummyMonster",
 			"startPosition": {
-				"x":0,
-				"y":0
+				"x":500,
+				"y":400
 			},
 			"startTime":0,
 			"id":2

--- a/Client/sprites/testPartition.partition
+++ b/Client/sprites/testPartition.partition
@@ -16,7 +16,8 @@
 				"x":0,
 				"y":0
 			},
-			"startTime":0
+			"startTime":0,
+			"id":1
 		},
 		{
 			"entityName":"DummyMonster",
@@ -24,7 +25,8 @@
 				"x":0,
 				"y":0
 			},
-			"startTime":0
+			"startTime":0,
+			"id":2
 		}
 	]
 }

--- a/Client/src/GameContext/ClientEntityPool.cpp
+++ b/Client/src/GameContext/ClientEntityPool.cpp
@@ -24,9 +24,9 @@ void ClientEntityPool::Draw(sf::RenderTexture &target, TextureBag &bag) {
 
 ClientEntityPool::ClientEntityPool(const std::shared_ptr<Timer> &timer) : EntityPool(timer) {}
 
-void ClientEntityPool::AddEntity(std::string const &entityName, vec2<float> const &initialPos, TimeRef const &startTime) {
+void ClientEntityPool::AddEntity(std::string const &entityName, uint16_t id, vec2<float> const &initialPos, TimeRef const &startTime) {
     auto now = startTime;
     auto pos = initialPos;
-    ManagedExternalInstance<Entity> entity(ExternalClassFactoryLoader::Instance->GetInstanceOf<Entity>("", "Drawable" + entityName, {_timer.get() , _eventManager.get(), &now, &pos }, "createDrawable", "destroyDrawable"));
+    ManagedExternalInstance<Entity> entity(ExternalClassFactoryLoader::Instance->GetInstanceOf<Entity>("", "Drawable" + entityName, { &id, _timer.get(), _eventManager.get(), &now, &pos }, "createDrawable", "destroyDrawable"));
     _pool.push_back(entity);
 }

--- a/Client/src/GameContext/ClientEntityPool.cpp
+++ b/Client/src/GameContext/ClientEntityPool.cpp
@@ -27,6 +27,6 @@ ClientEntityPool::ClientEntityPool(const std::shared_ptr<Timer> &timer) : Entity
 void ClientEntityPool::AddEntity(std::string const &entityName, uint16_t id, vec2<float> const &initialPos, TimeRef const &startTime, std::initializer_list<void *> *params) {
     auto now = startTime;
     auto pos = initialPos;
-    ManagedExternalInstance<Entity> entity(ExternalClassFactoryLoader::Instance->GetInstanceOf<Entity>("", "Drawable" + entityName, { &id, _timer.get(), _eventManager.get(), &now, &pos, params }, "createDrawable", "destroyDrawable"));
+    ManagedExternalInstance<Entity> entity(ExternalClassFactoryLoader::Instance->GetInstanceOf<Entity>("", "Drawable" + entityName, { &id, _timer.get(), _eventManager, &now, &pos, params }, "createDrawable", "destroyDrawable"));
     _pool.push_back(entity);
 }

--- a/Client/src/GameContext/ClientEntityPool.cpp
+++ b/Client/src/GameContext/ClientEntityPool.cpp
@@ -24,9 +24,9 @@ void ClientEntityPool::Draw(sf::RenderTexture &target, TextureBag &bag) {
 
 ClientEntityPool::ClientEntityPool(const std::shared_ptr<Timer> &timer) : EntityPool(timer) {}
 
-void ClientEntityPool::AddEntity(std::string const &entityName, uint16_t id, vec2<float> const &initialPos, TimeRef const &startTime) {
+void ClientEntityPool::AddEntity(std::string const &entityName, uint16_t id, vec2<float> const &initialPos, TimeRef const &startTime, std::initializer_list<void *> *params) {
     auto now = startTime;
     auto pos = initialPos;
-    ManagedExternalInstance<Entity> entity(ExternalClassFactoryLoader::Instance->GetInstanceOf<Entity>("", "Drawable" + entityName, { &id, _timer.get(), _eventManager.get(), &now, &pos }, "createDrawable", "destroyDrawable"));
+    ManagedExternalInstance<Entity> entity(ExternalClassFactoryLoader::Instance->GetInstanceOf<Entity>("", "Drawable" + entityName, { &id, _timer.get(), _eventManager.get(), &now, &pos, params }, "createDrawable", "destroyDrawable"));
     _pool.push_back(entity);
 }

--- a/Server/CMakeLists.txt
+++ b/Server/CMakeLists.txt
@@ -14,7 +14,7 @@ set(SERVER_SOURCE_FILES
 IF (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 ELSE()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror -Wuninitialized -Winit-self -Weffc++ -Wno-unused-parameter -Wno-unused-private-field")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror -Wuninitialized -Winit-self -Wno-unused-parameter -Wno-unused-private-field")
 ENDIF()
 
 add_executable(R_Type_Server ${SERVER_SOURCE_FILES})

--- a/Shared/CMakeLists.txt
+++ b/Shared/CMakeLists.txt
@@ -43,7 +43,7 @@ set(SHARED_SOURCE_FILES
         Include/vec2.hpp
         Include/Messages/FireProjectileMessage.hpp
 
-        Include/Json/Json.hpp)
+        Include/Json/Json.hpp Include/Messages/ProjectilePositionChangedMessage.hpp)
 
 include_directories(Libs/Interfaces
         ../SFML/include

--- a/Shared/EntityPool/EntityPool.cpp
+++ b/Shared/EntityPool/EntityPool.cpp
@@ -5,10 +5,10 @@
 #include <EntityPool/EntityPool.hpp>
 #include <Json/Json.hpp>
 
-void EntityPool::AddEntity(std::string const &entityName, vec2<float> const &initialPos, TimeRef const &timeRef) {
+void EntityPool::AddEntity(std::string const &entityName, uint16_t id, vec2<float> const &initialPos, TimeRef const &timeRef) {
     auto now = timeRef;
     auto pos = initialPos;
-    ManagedExternalInstance<Entity> entity(ExternalClassFactoryLoader::Instance->GetInstanceOf<Entity>("", entityName, {_timer.get() , _eventManager.get(), &now, &pos }, "create", "destroy"));
+    ManagedExternalInstance<Entity> entity(ExternalClassFactoryLoader::Instance->GetInstanceOf<Entity>("", entityName, { &id, _timer.get() , _eventManager.get(), &now, &pos }, "create", "destroy"));
     _pool.push_back(entity);
 }
 
@@ -42,7 +42,7 @@ bool EntityPool::GarbageEntities(const ManagedExternalInstance<Entity> &entity) 
 }
 
 void EntityPool::SpawnProjectile(FireProjectileMessage const &message) {
-    AddEntity(message.getProjectileName(), message.getSpawnPosition(), _timer->getCurrent());
+    AddEntity(message.getProjectileName(), 10, message.getSpawnPosition(), _timer->getCurrent());
 }
 
 void EntityPool::LoadPartition(std::string const &partition) {
@@ -53,6 +53,7 @@ void EntityPool::LoadPartition(std::string const &partition) {
         std::string name = i["entityName"];
         vec2<float> startPos(i["startPosition"]["x"], i["startPosition"]["y"]);
         TimeRef startTime((std::chrono::milliseconds(i["startTime"])));
-        AddEntity(name, startPos, startTime);
+        uint16_t id = i["id"];
+        AddEntity(name, id, startPos, startTime);
     }
 }

--- a/Shared/EntityPool/EntityPool.cpp
+++ b/Shared/EntityPool/EntityPool.cpp
@@ -8,7 +8,7 @@
 void EntityPool::AddEntity(std::string const &entityName, uint16_t id, vec2<float> const &initialPos, TimeRef const &timeRef, std::initializer_list<void *> *params) {
     auto now = timeRef;
     auto pos = initialPos;
-    ManagedExternalInstance<Entity> entity(ExternalClassFactoryLoader::Instance->GetInstanceOf<Entity>("", entityName, { &id, _timer.get() , _eventManager.get(), &now, &pos, params }, "create", "destroy"));
+    ManagedExternalInstance<Entity> entity(ExternalClassFactoryLoader::Instance->GetInstanceOf<Entity>("", entityName, { &id, _timer.get() , _eventManager, &now, &pos, params }, "create", "destroy"));
     _pool.push_back(entity);
 }
 
@@ -20,7 +20,7 @@ EntityPool::EntityPool(std::shared_ptr<Timer> const &timer) : _timer(timer) {
     });
 }
 
-const std::shared_ptr<RType::EventManager> &EntityPool::getEventManager() const {
+const RType::EventManager *EntityPool::getEventManager() const {
     return _eventManager;
 }
 

--- a/Shared/EntityPool/EntityPool.cpp
+++ b/Shared/EntityPool/EntityPool.cpp
@@ -5,18 +5,18 @@
 #include <EntityPool/EntityPool.hpp>
 #include <Json/Json.hpp>
 
-void EntityPool::AddEntity(std::string const &entityName, uint16_t id, vec2<float> const &initialPos, TimeRef const &timeRef) {
+void EntityPool::AddEntity(std::string const &entityName, uint16_t id, vec2<float> const &initialPos, TimeRef const &timeRef, std::initializer_list<void *> *params) {
     auto now = timeRef;
     auto pos = initialPos;
-    ManagedExternalInstance<Entity> entity(ExternalClassFactoryLoader::Instance->GetInstanceOf<Entity>("", entityName, { &id, _timer.get() , _eventManager.get(), &now, &pos }, "create", "destroy"));
+    ManagedExternalInstance<Entity> entity(ExternalClassFactoryLoader::Instance->GetInstanceOf<Entity>("", entityName, { &id, _timer.get() , _eventManager.get(), &now, &pos, params }, "create", "destroy"));
     _pool.push_back(entity);
 }
 
 EntityPool::~EntityPool() { }
 
 EntityPool::EntityPool(std::shared_ptr<Timer> const &timer) : _timer(timer) {
-    _eventListener.Subscribe<Entity, FireProjectileMessage>(FireProjectileMessage::EventType, [&](Entity *, FireProjectileMessage *message) {
-        SpawnProjectile(*message);
+    _eventListener.Subscribe<Entity, FireProjectileMessage>(FireProjectileMessage::EventType, [&](Entity *sender, FireProjectileMessage *message) {
+        SpawnProjectile(*message, sender->getId());
     });
 }
 
@@ -41,8 +41,9 @@ bool EntityPool::GarbageEntities(const ManagedExternalInstance<Entity> &entity) 
     return true;
 }
 
-void EntityPool::SpawnProjectile(FireProjectileMessage const &message) {
-    AddEntity(message.getProjectileName(), 10, message.getSpawnPosition(), _timer->getCurrent());
+void EntityPool::SpawnProjectile(FireProjectileMessage const &message, uint16_t emitterId) {
+    std::initializer_list<void *> params = { &emitterId };
+    AddEntity(message.getProjectileName(), 10, message.getSpawnPosition(), _timer->getCurrent(), &params);
 }
 
 void EntityPool::LoadPartition(std::string const &partition) {

--- a/Shared/Include/Entities/Entity.hpp
+++ b/Shared/Include/Entities/Entity.hpp
@@ -8,12 +8,20 @@
 #include <algorithm>
 #include "Trait.hpp"
 #include <vector>
+#include <Time/Timer.hpp>
+#include <EventDispatcher/EventManager.hpp>
 
 class Entity {
 protected:
+    uint16_t _id;
+    Timer *_timer = nullptr;
+    RType::EventManager *_eventManager;
+
     std::vector<Trait> _traits = std::vector<Trait>();
 public:
     virtual ~Entity() { }
+
+    Entity(uint16_t _id, Timer *timer, RType::EventManager *eventMgr) : _id(_id), _timer(timer), _eventManager(eventMgr) {}
 
     virtual bool ImplementTrait(Trait trait) {
         for(auto x : _traits)

--- a/Shared/Include/Entities/Entity.hpp
+++ b/Shared/Include/Entities/Entity.hpp
@@ -38,6 +38,10 @@ public:
         RegisterTrait(Garbage);
     }
 
+    uint16_t getId() const {
+        return _id;
+    }
+
     virtual void Cycle() = 0;
 };
 

--- a/Shared/Include/EntityPool/EntityPool.hpp
+++ b/Shared/Include/EntityPool/EntityPool.hpp
@@ -20,7 +20,7 @@ class EntityPool {
 protected:
     std::vector<ManagedExternalInstance<Entity>> _pool = std::vector<ManagedExternalInstance<Entity>>();
     std::shared_ptr<RType::EventManager> _eventManager = std::make_shared<RType::EventManager>();
-    RType::EventListener _eventListener = RType::EventListener(_eventManager);
+    RType::EventListener _eventListener = RType::EventListener(_eventManager.get());
     std::shared_ptr<Timer> _timer;
 
 public:

--- a/Shared/Include/EntityPool/EntityPool.hpp
+++ b/Shared/Include/EntityPool/EntityPool.hpp
@@ -29,7 +29,7 @@ public:
     virtual ~EntityPool();
 
 public:
-    virtual void AddEntity(std::string const &entityName, vec2<float> const &initialPos, TimeRef const & = TimeRef());
+    virtual void AddEntity(std::string const &entityName, uint16_t id, vec2<float> const &initialPos, TimeRef const & = TimeRef());
     virtual void ProcessEntities();
     void LoadPartition(std::string const &);
 

--- a/Shared/Include/EntityPool/EntityPool.hpp
+++ b/Shared/Include/EntityPool/EntityPool.hpp
@@ -14,6 +14,7 @@
 #include "EventDispatcher/EventListener.hpp"
 #include <LibraryLoader/ExternalClassFactoryLoader.hpp>
 #include <Time/Timer.hpp>
+#include <initializer_list>
 
 class EntityPool {
 protected:
@@ -29,7 +30,7 @@ public:
     virtual ~EntityPool();
 
 public:
-    virtual void AddEntity(std::string const &entityName, uint16_t id, vec2<float> const &initialPos, TimeRef const & = TimeRef());
+    virtual void AddEntity(std::string const &entityName, uint16_t id, vec2<float> const &initialPos, TimeRef const &, std::initializer_list<void *> * = nullptr);
     virtual void ProcessEntities();
     void LoadPartition(std::string const &);
 
@@ -37,7 +38,7 @@ public:
     const std::shared_ptr<RType::EventManager> &getEventManager() const;
 
 private:
-    void SpawnProjectile(FireProjectileMessage const &);
+    void SpawnProjectile(FireProjectileMessage const &, const uint16_t emitterId);
 
 private:
     bool GarbageEntities(const ManagedExternalInstance<Entity> &entity);

--- a/Shared/Include/EntityPool/EntityPool.hpp
+++ b/Shared/Include/EntityPool/EntityPool.hpp
@@ -19,8 +19,8 @@
 class EntityPool {
 protected:
     std::vector<ManagedExternalInstance<Entity>> _pool = std::vector<ManagedExternalInstance<Entity>>();
-    std::shared_ptr<RType::EventManager> _eventManager = std::make_shared<RType::EventManager>();
-    RType::EventListener _eventListener = RType::EventListener(_eventManager.get());
+    RType::EventManager *_eventManager = new RType::EventManager();
+    RType::EventListener _eventListener = RType::EventListener(_eventManager);
     std::shared_ptr<Timer> _timer;
 
 public:
@@ -35,7 +35,7 @@ public:
     void LoadPartition(std::string const &);
 
 public:
-    const std::shared_ptr<RType::EventManager> &getEventManager() const;
+    const RType::EventManager *getEventManager() const;
 
 private:
     void SpawnProjectile(FireProjectileMessage const &, const uint16_t emitterId);

--- a/Shared/Include/EventDispatcher/EventListener.hpp
+++ b/Shared/Include/EventDispatcher/EventListener.hpp
@@ -15,14 +15,19 @@ namespace RType {
         typedef std::map<RType::Event, std::vector<std::function<void(void *, IMessage *message)>>> callback_map;
 
     private:
-        std::shared_ptr<RType::EventManager> _eventManager = nullptr;
+        RType::EventManager *_eventManager = nullptr;
         std::shared_ptr<callback_map> _callbacks;
 
     public:
-        EventListener(std::shared_ptr<RType::EventManager> eventManager) :
+        EventListener(RType::EventManager *eventManager) :
                 _eventManager(eventManager),
                 _callbacks(std::shared_ptr<callback_map>(new callback_map())) {
             _eventManager->AddListener(_callbacks);
+        }
+
+        virtual ~EventListener() {
+            (*_callbacks).clear();
+            _eventManager->EraseListener(_callbacks);
         }
 
         template<typename EntityType, typename MessageType>

--- a/Shared/Include/EventDispatcher/EventListener.hpp
+++ b/Shared/Include/EventDispatcher/EventListener.hpp
@@ -26,8 +26,8 @@ namespace RType {
         }
 
         virtual ~EventListener() {
-            (*_callbacks).clear();
             _eventManager->EraseListener(_callbacks);
+            //(*_callbacks).clear();
         }
 
         template<typename EntityType, typename MessageType>

--- a/Shared/Include/EventDispatcher/EventManager.hpp
+++ b/Shared/Include/EventDispatcher/EventManager.hpp
@@ -10,10 +10,8 @@
 #include <vector>
 #include <memory>
 #include <algorithm>
+#include <EventDispatcher/IMessage.hpp>
 #include "Events.h"
-#include <EventDispatcher/IMessage.hpp>
-#include <Entities/Entity.hpp>
-#include <EventDispatcher/IMessage.hpp>
 
 /*
  * Usage exemple

--- a/Shared/Include/EventDispatcher/EventManager.hpp
+++ b/Shared/Include/EventDispatcher/EventManager.hpp
@@ -43,6 +43,18 @@ namespace RType {
             _listeners.push_back(callbacks);
         }
 
+        void
+        EraseListener(std::shared_ptr<std::map<RType::Event, std::vector<std::function<void(void *, IMessage *message)>>>> &callbacks){
+            auto index = 0;
+            for(std::shared_ptr<std::map<RType::Event, std::vector<std::function<void(void *, IMessage *message)>>>> const &i : _listeners) {
+                if (i == callbacks)
+                {
+                    _listeners.erase(_listeners.begin() + index);
+                    index++;
+                }
+            }
+        }
+
         void Emit(RType::Event event, IMessage *message, void *sender) {
             for (auto const callbacklist : _listeners) {
                 if (callbacklist != nullptr)

--- a/Shared/Include/EventDispatcher/EventManager.hpp
+++ b/Shared/Include/EventDispatcher/EventManager.hpp
@@ -43,15 +43,12 @@ namespace RType {
             _listeners.push_back(callbacks);
         }
 
-        void
-        EraseListener(std::shared_ptr<std::map<RType::Event, std::vector<std::function<void(void *, IMessage *message)>>>> &callbacks){
+        void EraseListener(std::shared_ptr<std::map<RType::Event, std::vector<std::function<void(void *, IMessage *message)>>>> &callbacks){
             auto index = 0;
             for(std::shared_ptr<std::map<RType::Event, std::vector<std::function<void(void *, IMessage *message)>>>> const &i : _listeners) {
                 if (i == callbacks)
-                {
                     _listeners.erase(_listeners.begin() + index);
-                    index++;
-                }
+                index++;
             }
         }
 

--- a/Shared/Include/EventDispatcher/Events.h
+++ b/Shared/Include/EventDispatcher/Events.h
@@ -10,7 +10,8 @@ namespace RType {
     enum Event {
         BULLET_DAMAGE_CHANGE,
         BULLET_POS_CHANGE,
-        NEW_ENTITY
+        NEW_ENTITY,
+        POSITION_CHANGED_COLLISION
     };
 }
 

--- a/Shared/Include/Messages/ProjectilePositionChangedMessage.hpp
+++ b/Shared/Include/Messages/ProjectilePositionChangedMessage.hpp
@@ -9,6 +9,7 @@
 #include <EventDispatcher/Events.h>
 #include <vec2.hpp>
 #include <string>
+#include <Entities/Entity.hpp>
 
 class ProjectilePositionChangedMessage : public IMessage {
 public:
@@ -17,10 +18,11 @@ public:
 private:
     vec2<float> _projectilePosition;
     const uint16_t _emitterId;
+    bool _shouldDestroyProjectileOnHit;
 
 public:
-    ProjectilePositionChangedMessage(const uint16_t emitterId, const vec2<float> &position) :
-            _projectilePosition(position), _emitterId(emitterId) {}
+    ProjectilePositionChangedMessage(const uint16_t emitterId, const vec2<float> &position, bool shouldDestroyOnHit) :
+            _projectilePosition(position), _emitterId(emitterId), _shouldDestroyProjectileOnHit(shouldDestroyOnHit) {}
 
     const uint16_t &getEmitterId() const {
         return _emitterId;
@@ -31,9 +33,12 @@ public:
     }
 
     bool TestHitBox(vec2<float> pos, vec2<float> size, uint16_t id) {
-        if (_projectilePosition.Intersect(pos, pos + size) && id != _emitterId)
-            return true;
-        return false;
+        return _projectilePosition.Intersect(pos, pos + size) && id != _emitterId;
+    }
+
+    void DidHit(Entity *sender){
+        if (_shouldDestroyProjectileOnHit)
+            sender->Destroy();
     }
 };
 

--- a/Shared/Include/Messages/ProjectilePositionChangedMessage.hpp
+++ b/Shared/Include/Messages/ProjectilePositionChangedMessage.hpp
@@ -1,0 +1,29 @@
+//
+// Created by hippolyteb on 12/10/16.
+//
+
+#ifndef R_TYPE_PROJECTILEPOSITIONCHANGEDMESSAGE_HPP
+#define R_TYPE_PROJECTILEPOSITIONCHANGEDMESSAGE_HPP
+
+#include <EventDispatcher/IMessage.hpp>
+#include <EventDispatcher/Events.h>
+#include <vec2.hpp>
+#include <string>
+
+class ProjectilePositionChangedMessage : public IMessage {
+public:
+    static constexpr RType::Event EventType = RType::POSITION_CHANGED_COLLISION;
+
+private:
+    const vec2<float> _projectilePosition;
+
+public:
+    ProjectilePositionChangedMessage(const vec2<float> &position) :
+            _projectilePosition(position) {}
+
+    const vec2<float> &getProjectilePosition() const {
+        return _projectilePosition;
+    }
+};
+
+#endif //R_TYPE_PROJECTILEPOSITIONCHANGEDMESSAGE_HPP

--- a/Shared/Include/Messages/ProjectilePositionChangedMessage.hpp
+++ b/Shared/Include/Messages/ProjectilePositionChangedMessage.hpp
@@ -16,10 +16,15 @@ public:
 
 private:
     const vec2<float> _projectilePosition;
+    const uint16_t _emitterId;
 
 public:
-    ProjectilePositionChangedMessage(const vec2<float> &position) :
-            _projectilePosition(position) {}
+    ProjectilePositionChangedMessage(const uint16_t emitterId, const vec2<float> &position) :
+            _projectilePosition(position), _emitterId(emitterId) {}
+
+    const uint16_t &getEmitterId() const {
+        return _emitterId;
+    }
 
     const vec2<float> &getProjectilePosition() const {
         return _projectilePosition;

--- a/Shared/Include/Messages/ProjectilePositionChangedMessage.hpp
+++ b/Shared/Include/Messages/ProjectilePositionChangedMessage.hpp
@@ -15,7 +15,7 @@ public:
     static constexpr RType::Event EventType = RType::POSITION_CHANGED_COLLISION;
 
 private:
-    const vec2<float> _projectilePosition;
+    vec2<float> _projectilePosition;
     const uint16_t _emitterId;
 
 public:
@@ -28,6 +28,12 @@ public:
 
     const vec2<float> &getProjectilePosition() const {
         return _projectilePosition;
+    }
+
+    bool TestHitBox(vec2<float> pos, vec2<float> size, uint16_t id) {
+        if (_projectilePosition.Intersect(pos, pos + size) && id != _emitterId)
+            return true;
+        return false;
     }
 };
 

--- a/Shared/Include/PartitionSystem/EntityPartition.hpp
+++ b/Shared/Include/PartitionSystem/EntityPartition.hpp
@@ -45,6 +45,8 @@ public:
     }
 
     bool ShouldFire(TimeRef const &timeRef) {
+        if (_segments.size() == 0)
+            return false;
         auto start = getStart();
         auto end = getEnd();
         if (timeRef < start || timeRef > end)

--- a/Shared/Include/vec2.hpp
+++ b/Shared/Include/vec2.hpp
@@ -125,6 +125,12 @@ public:
         return vec2(y, -x);
     }
 
+    bool Intersect(vec2 first, vec2 second) {
+        if (x >= first.x && x <= second.x && y >= first.y && y <= second.y)
+            return true;
+        return false;
+    }
+
     static float dot(vec2 v1, vec2 v2) {
         return v1.x * v2.x + v1.y * v2.y;
     }

--- a/Shared/Include/vec2.hpp
+++ b/Shared/Include/vec2.hpp
@@ -126,9 +126,7 @@ public:
     }
 
     bool Intersect(vec2 first, vec2 second) {
-        if (x >= first.x && x <= second.x && y >= first.y && y <= second.y)
-            return true;
-        return false;
+        return x >= first.x && x <= second.x && y >= first.y && y <= second.y;
     }
 
     static float dot(vec2 v1, vec2 v2) {

--- a/Shared/UnitTests/EventDispatcher/EventDispatcherTest.cpp
+++ b/Shared/UnitTests/EventDispatcher/EventDispatcherTest.cpp
@@ -18,7 +18,7 @@ TEST(Tests_EventDispatcher, EmitEventWithSubscribeAndUnsunbscribe) {
 
     RType::Bullet bulletEntity;
     std::shared_ptr<RType::EventManager> e = std::shared_ptr<RType::EventManager>(new RType::EventManager);
-    RType::EventListener listener(e);
+    RType::EventListener listener(e.get());
 
     listener.Subscribe<RType::Bullet, void>(RType::BULLET_POS_CHANGE, [](RType::Bullet *bullet, void *) {
         bullet->a = 42;

--- a/Shared/UnitTests/EventDispatcher/EventDispatcherTest.cpp
+++ b/Shared/UnitTests/EventDispatcher/EventDispatcherTest.cpp
@@ -8,13 +8,9 @@
 
 // Entity model
 namespace RType {
-    class Bullet : public Entity {
+    class Bullet {
     public:
         int a = 0;
-
-        Bullet() : Entity() {}
-
-        void Cycle() override {}
     };
 }
 

--- a/SharedLibs/Base.h
+++ b/SharedLibs/Base.h
@@ -5,6 +5,8 @@
 #ifndef R_TYPE_BASE_H
 #define R_TYPE_BASE_H
 
+#include <initializer_list>
+
 #if MSVC
 #define DLLEXPORT __declspec(dllexport)
 #else

--- a/SharedLibs/Entities/CMakeLists.txt
+++ b/SharedLibs/Entities/CMakeLists.txt
@@ -2,3 +2,4 @@ cmake_minimum_required(VERSION 2.6.2)
 
 add_subdirectory(Monsters)
 add_subdirectory(Projectiles)
+add_subdirectory(Player)

--- a/SharedLibs/Entities/Monsters/DummyMonster/DummyMonster.cpp
+++ b/SharedLibs/Entities/Monsters/DummyMonster/DummyMonster.cpp
@@ -28,12 +28,12 @@ DummyMonster::DummyMonster(uint16_t id, Timer *timer, RType::EventManager *event
             .Loop(3)*/
             .Build();
 
-    _eventListener->Subscribe<Entity, ProjectilePositionChangedMessage>(ProjectilePositionChangedMessage::EventType, [&](Entity *, ProjectilePositionChangedMessage *message) {
+    _eventListener->Subscribe<Entity, ProjectilePositionChangedMessage>(ProjectilePositionChangedMessage::EventType, [&](Entity *sender, ProjectilePositionChangedMessage *message) {
         auto segment = _partition.GetCurrentSegment(_timer->getCurrent());
         if (message->TestHitBox(segment->getLocationVector().GetTweened(), vec2<float>(32 * 5, 14 * 5), _id))
         {
+            message->DidHit(sender);
             this->Destroy();
-            //_eventListener->Unsubscribe(ProjectilePositionChangedMessage::EventType);
         }
     });
 }

--- a/SharedLibs/Entities/Monsters/DummyMonster/DummyMonster.cpp
+++ b/SharedLibs/Entities/Monsters/DummyMonster/DummyMonster.cpp
@@ -8,9 +8,9 @@
 #include <PartitionSystem/Tween/Curve/EaseOutCurve.hpp>
 #include <Messages/FireProjectileMessage.hpp>
 
-DummyMonster::DummyMonster(const std::initializer_list<void *> init) : DummyMonster(GetParamFromInitializerList<Timer*>(init, 0), GetParamFromInitializerList<RType::EventManager*>(init, 1), *GetParamFromInitializerList<TimeRef*>(init, 2), *GetParamFromInitializerList<vec2<float>*>(init, 3)) { }
+DummyMonster::DummyMonster(const std::initializer_list<void *> init) : DummyMonster(*GetParamFromInitializerList<uint16_t *>(init, 0), GetParamFromInitializerList<Timer*>(init, 1), GetParamFromInitializerList<RType::EventManager*>(init, 2), *GetParamFromInitializerList<TimeRef*>(init, 3), *GetParamFromInitializerList<vec2<float>*>(init, 4)) { }
 
-DummyMonster::DummyMonster(Timer *timer, RType::EventManager *eventManager, TimeRef const &timeRef, vec2<float> const &startPosition) : _timer(timer), _eventManager(eventManager) {
+DummyMonster::DummyMonster(uint16_t id, Timer *timer, RType::EventManager *eventManager, TimeRef const &timeRef, vec2<float> const &startPosition) : Entity(id, timer, eventManager) {
     _partition = EntityPartitionBuilder(timer, timeRef, startPosition).AddSegment(
                     PartitionSegmentBuilder()
                             .Begins(timeRef)

--- a/SharedLibs/Entities/Monsters/DummyMonster/DummyMonster.cpp
+++ b/SharedLibs/Entities/Monsters/DummyMonster/DummyMonster.cpp
@@ -4,27 +4,38 @@
 
 #include "DummyMonster.hpp"
 #include <PartitionSystem/EntityPartitionBuilder.hpp>
-#include <PartitionSystem/Tween/Curve/EaseInOutCurve.hpp>
-#include <PartitionSystem/Tween/Curve/EaseOutCurve.hpp>
 #include <Messages/FireProjectileMessage.hpp>
+#include <Messages/ProjectilePositionChangedMessage.hpp>
+#include <iostream>
 
 DummyMonster::DummyMonster(const std::initializer_list<void *> init) : DummyMonster(*GetParamFromInitializerList<uint16_t *>(init, 0), GetParamFromInitializerList<Timer*>(init, 1), GetParamFromInitializerList<RType::EventManager*>(init, 2), *GetParamFromInitializerList<TimeRef*>(init, 3), *GetParamFromInitializerList<vec2<float>*>(init, 4)) { }
 
-DummyMonster::DummyMonster(uint16_t id, Timer *timer, RType::EventManager *eventManager, TimeRef const &timeRef, vec2<float> const &startPosition) : Entity(id, timer, eventManager) {
+DummyMonster::DummyMonster(uint16_t id, Timer *timer, RType::EventManager *eventManager, TimeRef const &timeRef, vec2<float> const &startPosition) :
+        Entity(id, timer, eventManager)
+{
+    _eventListener = std::unique_ptr<RType::EventListener>(new RType::EventListener(eventManager));
     _partition = EntityPartitionBuilder(timer, timeRef, startPosition).AddSegment(
                     PartitionSegmentBuilder()
                             .Begins(timeRef)
-                            .For(std::chrono::seconds(10))
-                            .Translate(vec2<float>(500, 500))
-                            .WithCurving(new EaseInOutCurve())
+                            .For(std::chrono::seconds(10000))
+                            .Translate(vec2<float>(0, 0))
                             .Fire("SimpleProjectile", 1))
-            .AddSegment(PartitionSegmentBuilder()
+            /*.AddSegment(PartitionSegmentBuilder()
                                 .For(std::chrono::seconds(5))
                                 .Translate(vec2<float>(-400, -400))
                                 .WithCurving(new EaseOutCurve())
                                 .Fire("SimpleProjectile", 3))
-            .Loop(3)
+            .Loop(3)*/
             .Build();
+
+    _eventListener->Subscribe<Entity, ProjectilePositionChangedMessage>(ProjectilePositionChangedMessage::EventType, [&](Entity *, ProjectilePositionChangedMessage *message) {
+        auto segment = _partition.GetCurrentSegment(_timer->getCurrent());
+        if (message->TestHitBox(segment->getLocationVector().GetTweened(), vec2<float>(32 * 5, 14 * 5), _id))
+        {
+            this->Destroy();
+            //_eventListener->Unsubscribe(ProjectilePositionChangedMessage::EventType);
+        }
+    });
 }
 
 void DummyMonster::Cycle() {

--- a/SharedLibs/Entities/Monsters/DummyMonster/DummyMonster.hpp
+++ b/SharedLibs/Entities/Monsters/DummyMonster/DummyMonster.hpp
@@ -14,13 +14,11 @@
 
 class DummyMonster : public Entity {
 protected:
-    Timer *_timer = nullptr;
     EntityPartition _partition = EntityPartition(_timer);
-    RType::EventManager *_eventManager;
 
 public:
     DummyMonster(const std::initializer_list<void *> init);
-    DummyMonster(Timer *, RType::EventManager *, TimeRef const &, vec2<float> const &);
+    DummyMonster(uint16_t, Timer *, RType::EventManager *, TimeRef const &, vec2<float> const &);
 
     void Cycle() override;
 };

--- a/SharedLibs/Entities/Monsters/DummyMonster/DummyMonster.hpp
+++ b/SharedLibs/Entities/Monsters/DummyMonster/DummyMonster.hpp
@@ -10,11 +10,13 @@
 #include <Base.h>
 #include <Entities/Entity.hpp>
 #include <EventDispatcher/EventManager.hpp>
+#include <EventDispatcher/EventListener.hpp>
 #include "PartitionSystem/PartitionSegmentBuilder.hpp"
 
 class DummyMonster : public Entity {
 protected:
     EntityPartition _partition = EntityPartition(_timer);
+    std::unique_ptr<RType::EventListener> _eventListener;
 
 public:
     DummyMonster(const std::initializer_list<void *> init);

--- a/SharedLibs/Entities/Player/CMakeLists.txt
+++ b/SharedLibs/Entities/Player/CMakeLists.txt
@@ -6,8 +6,6 @@ ELSE()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror -Wuninitialized -Winit-self -Wno-unused-parameter")
 ENDIF()
 
-include_directories(../../../SFML/include)
-
 add_library(Player SHARED
         Player.hpp
         Player.cpp)

--- a/SharedLibs/Entities/Player/GraphicPlayer.cpp
+++ b/SharedLibs/Entities/Player/GraphicPlayer.cpp
@@ -2,27 +2,42 @@
 // Created by hippolyteb on 11/29/16.
 //
 
+#include <Entities/Trait.hpp>
 #include "GraphicPlayer.hpp"
 
-GraphicPlayer::GraphicPlayer(Timer *timer) : Player(timer) {}
+GraphicPlayer::GraphicPlayer(const std::initializer_list<void *> init) : Player(init) {
+    this->RegisterTrait(Trait::Drawable);
+}
 
-void GraphicPlayer::Draw(sf::RenderTexture &rect) {
-    sf::Texture texture;
-    rect.clear(sf::Color::Transparent);
-    texture.loadFromFile("sprites/r-typesheet1.png", sf::IntRect(101, 3, 32, 14));
+void GraphicPlayer::Draw(sf::RenderTexture *rect, TextureBag &bag) {
+
+    auto texture = bag.getTexture("sprites/r-typesheet1.png", sf::IntRect(101, 3, 32, 14));
+
+    rect->clear(sf::Color::Transparent);
+    if (texture == nullptr) {
+        sf::Texture newtexture;
+        newtexture.loadFromFile("sprites/r-typesheet1.png", sf::IntRect(101, 3, 32, 14));
+        texture = bag.AddTexture("sprites/r-typesheet1.png", sf::IntRect(101, 3, 32, 14), newtexture);
+    }
+
     sf::Sprite sprite;
-    sprite.setTexture(texture);
+    sprite.setTexture(*texture);
     sprite.setScale(sf::Vector2f(5.f, 5.f));
-    rect.draw(sprite);
+    rect->draw(sprite);
 }
 
-vec2<int> GraphicPlayer::GetRenderRect() {
-    return vec2<int>(32 * 5, 14 * 5);
+vec2<float> GraphicPlayer::GetRenderRect() {
+    return vec2<float>(32 * 5, 14 * 5);
 }
 
-vec2<int> GraphicPlayer::GetPosition() {
-    auto pos = _partition.GetCurrentSegment(_timer->getCurrent()).getLocationVector().GetTweened();
-    return pos;
+vec2<float> GraphicPlayer::GetPosition() {
+    //auto pos = _partition.GetCurrentSegment(_timer->getCurrent())->getLocationVector().GetTweened();
+    //return pos;
+    return vec2<float>(2, 2);
+}
+
+void GraphicPlayer::Cycle() {
+    GraphicPlayer::Cycle();
 }
 
 RTYPE_DRAWABLE_ENTITY_REGISTER(GraphicPlayer)

--- a/SharedLibs/Entities/Player/GraphicPlayer.cpp
+++ b/SharedLibs/Entities/Player/GraphicPlayer.cpp
@@ -37,7 +37,7 @@ vec2<float> GraphicPlayer::GetPosition() {
 }
 
 void GraphicPlayer::Cycle() {
-    GraphicPlayer::Cycle();
+    Player::Cycle();
 }
 
 RTYPE_DRAWABLE_ENTITY_REGISTER(GraphicPlayer)

--- a/SharedLibs/Entities/Player/GraphicPlayer.hpp
+++ b/SharedLibs/Entities/Player/GraphicPlayer.hpp
@@ -5,17 +5,20 @@
 #ifndef R_TYPE_GRAPHICDUMMYMONSTER_HPP
 #define R_TYPE_GRAPHICDUMMYMONSTER_HPP
 
+#include <IDrawable.hpp>
 #include "Player.hpp"
 
-class GraphicPlayer : DrawableEntity, public Player {
+class GraphicPlayer : public Player, public IDrawable {
 
 public:
-    GraphicPlayer(Timer *timer);
+    GraphicPlayer(const std::initializer_list<void *> init);
 
 public:
-    void Draw(sf::RenderTexture &rect) override;
-    vec2<int> GetRenderRect() override;
-    vec2<int> GetPosition() override;
+    void Draw(sf::RenderTexture *rect, TextureBag &) override;
+    vec2<float> GetRenderRect() override;
+    vec2<float> GetPosition() override;
+
+    void Cycle() override;
 };
 
 #endif //R_TYPE_GRAPHICDUMMYMONSTER_HPP

--- a/SharedLibs/Entities/Player/Player.cpp
+++ b/SharedLibs/Entities/Player/Player.cpp
@@ -2,28 +2,21 @@
 // Created by hippolyteb on 11/25/16.
 //
 
-#include <iostream>
-#include <thread>
 #include "Player.hpp"
-#include <PartitionSystem/EntityPartitionBuilder.hpp>
-#include <PartitionSystem/Tween/Curve/EaseInOutCurve.hpp>
-#include <PartitionSystem/Tween/Curve/EaseOutCurve.hpp>
+#include <Messages/FireProjectileMessage.hpp>
 
-Player::Player(Timer *timer) : _timer(timer), _partition(timer) {
-    _partition = EntityPartitionBuilder(timer).AddSegment(
-                    PartitionSegmentBuilder()
-                            .Begins(_timer->getCurrent())
-                            .For(std::chrono::seconds(5))
-                            .From(vec2<int>(0, 0))
-                            .To(vec2<int>(500, 500))
-                            .WithCurving(new EaseInOutCurve()))
-            .ContinueWith(PartitionSegmentBuilder()
-                                  .From(vec2<int>(500, 500))
-                                  .For(std::chrono::seconds(10))
-                                  .To(vec2<int>(100, 90))
-                                  .WithCurving(new EaseOutCurve()))
-            .Loop(2)
-            .Build();
+Player::Player(const std::initializer_list<void *> init) : Player(GetParamFromInitializerList<Timer*>(init, 0), GetParamFromInitializerList<RType::EventManager*>(init, 1), *GetParamFromInitializerList<TimeRef*>(init, 2), *GetParamFromInitializerList<vec2<float>*>(init, 3)) { }
+
+Player::Player(Timer *timer, RType::EventManager *eventManager, TimeRef const &timeRef, vec2<float> const &startPosition) : _timer(timer), _eventManager(eventManager) {
+
+}
+
+void Player::Cycle() {
+//    auto now = _timer->getCurrent();
+//    if (_partition.ShouldFire(now)) {
+//        auto segment = _partition.GetCurrentSegment(now);
+//        _eventManager->Emit(FireProjectileMessage::EventType, new FireProjectileMessage(segment->getCurrentProjectile(), segment->getLocationVector().GetTweened()), this);
+//    }
 }
 
 RTYPE_ENTITY_REGISTER(Player)

--- a/SharedLibs/Entities/Player/Player.cpp
+++ b/SharedLibs/Entities/Player/Player.cpp
@@ -5,9 +5,9 @@
 #include "Player.hpp"
 #include <Messages/FireProjectileMessage.hpp>
 
-Player::Player(const std::initializer_list<void *> init) : Player(GetParamFromInitializerList<Timer*>(init, 0), GetParamFromInitializerList<RType::EventManager*>(init, 1), *GetParamFromInitializerList<TimeRef*>(init, 2), *GetParamFromInitializerList<vec2<float>*>(init, 3)) { }
+Player::Player(const std::initializer_list<void *> init) : Player(*GetParamFromInitializerList<uint16_t  *>(init, 0), GetParamFromInitializerList<Timer*>(init, 1), GetParamFromInitializerList<RType::EventManager*>(init, 2), *GetParamFromInitializerList<TimeRef*>(init, 3), *GetParamFromInitializerList<vec2<float>*>(init, 4)) { }
 
-Player::Player(Timer *timer, RType::EventManager *eventManager, TimeRef const &timeRef, vec2<float> const &startPosition) : _timer(timer), _eventManager(eventManager) {
+Player::Player(uint16_t id, Timer *timer, RType::EventManager *eventManager, TimeRef const &timeRef, vec2<float> const &startPosition) : Entity(id, timer, eventManager) {
 
 }
 

--- a/SharedLibs/Entities/Player/Player.hpp
+++ b/SharedLibs/Entities/Player/Player.hpp
@@ -13,12 +13,10 @@
 
 class Player : public Entity {
 protected:
-    Timer *_timer = nullptr;
-    RType::EventManager *_eventManager;
 
 public:
     Player(const std::initializer_list<void *> init);
-    Player(Timer *, RType::EventManager *, TimeRef const &, vec2<float> const &);
+    Player(uint16_t, Timer *, RType::EventManager *, TimeRef const &, vec2<float> const &);
 
     void Cycle() override;
 };

--- a/SharedLibs/Entities/Player/Player.hpp
+++ b/SharedLibs/Entities/Player/Player.hpp
@@ -5,20 +5,22 @@
 #ifndef R_TYPE_DUMMYMONSTER_HPP
 #define R_TYPE_DUMMYMONSTER_HPP
 
-#include "PartitionSystem/EntityPartition.hpp"
-#include <Timer.hpp>
 #include <Base.h>
-#include <Interfaces/IDrawable.hpp>
-#include <Interfaces/Libs/DrawableEntity.hpp>
-#include "PartitionSystem/PartitionSegmentBuilder.hpp"
+#include <Entities/Entity.hpp>
+#include <EventDispatcher/EventManager.hpp>
+#include <Time/Timer.hpp>
+#include <vec2.hpp>
 
 class Player : public Entity {
 protected:
-    Timer *_timer;
-    EntityPartition _partition;
+    Timer *_timer = nullptr;
+    RType::EventManager *_eventManager;
 
 public:
-    Player(Timer *timer);
+    Player(const std::initializer_list<void *> init);
+    Player(Timer *, RType::EventManager *, TimeRef const &, vec2<float> const &);
+
+    void Cycle() override;
 };
 
 #endif //R_TYPE_DUMMYMONSTER_HPP

--- a/SharedLibs/Entities/Projectiles/SimpleProjectiles/DrawableSimpleProjectile.cpp
+++ b/SharedLibs/Entities/Projectiles/SimpleProjectiles/DrawableSimpleProjectile.cpp
@@ -31,7 +31,6 @@ vec2<float> DrawableSimpleProjectile::GetRenderRect() {
 
 vec2<float> DrawableSimpleProjectile::GetPosition() {
     auto pos = _partition.GetCurrentSegment(_timer->getCurrent())->getLocationVector().GetTweened();
-    _eventManager->Emit(ProjectilePositionChangedMessage::EventType, new ProjectilePositionChangedMessage(pos), this);
     return pos;
 }
 

--- a/SharedLibs/Entities/Projectiles/SimpleProjectiles/DrawableSimpleProjectile.cpp
+++ b/SharedLibs/Entities/Projectiles/SimpleProjectiles/DrawableSimpleProjectile.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <iostream>
+#include <Messages/ProjectilePositionChangedMessage.hpp>
 #include "DrawableSimpleProjectile.hpp"
 
 DrawableSimpleProjectile::DrawableSimpleProjectile(const std::initializer_list<void *> init) : SimpleProjectile(init) {
@@ -30,6 +31,7 @@ vec2<float> DrawableSimpleProjectile::GetRenderRect() {
 
 vec2<float> DrawableSimpleProjectile::GetPosition() {
     auto pos = _partition.GetCurrentSegment(_timer->getCurrent())->getLocationVector().GetTweened();
+    _eventManager->Emit(ProjectilePositionChangedMessage::EventType, new ProjectilePositionChangedMessage(pos), this);
     return pos;
 }
 

--- a/SharedLibs/Entities/Projectiles/SimpleProjectiles/SimpleProjectile.cpp
+++ b/SharedLibs/Entities/Projectiles/SimpleProjectiles/SimpleProjectile.cpp
@@ -9,9 +9,9 @@
 #include <PartitionSystem/Tween/Curve/EaseOutCurve.hpp>
 #include <iostream>
 
-SimpleProjectile::SimpleProjectile(const std::initializer_list<void *> init) : SimpleProjectile(GetParamFromInitializerList<Timer*>(init, 0), GetParamFromInitializerList<RType::EventManager*>(init, 1), *GetParamFromInitializerList<TimeRef*>(init, 2), *GetParamFromInitializerList<vec2<float>*>(init, 3)) { }
+SimpleProjectile::SimpleProjectile(const std::initializer_list<void *> init) : SimpleProjectile(*GetParamFromInitializerList<uint16_t *>(init, 0), GetParamFromInitializerList<Timer*>(init, 1), GetParamFromInitializerList<RType::EventManager*>(init, 2), *GetParamFromInitializerList<TimeRef*>(init, 3), *GetParamFromInitializerList<vec2<float>*>(init, 4)) { }
 
-SimpleProjectile::SimpleProjectile(Timer *timer, RType::EventManager *eventManager, TimeRef const &timeRef, vec2<float> const &startPosition) : _timer(timer), _eventManager(eventManager) {
+SimpleProjectile::SimpleProjectile(uint16_t id, Timer *timer, RType::EventManager *eventManager, TimeRef const &timeRef, vec2<float> const &startPosition) : Entity(id, timer, eventManager) {
     _partition = EntityPartitionBuilder(timer, timeRef, startPosition).AddSegment(
                     PartitionSegmentBuilder()
                             .Begins(timeRef)

--- a/SharedLibs/Entities/Projectiles/SimpleProjectiles/SimpleProjectile.cpp
+++ b/SharedLibs/Entities/Projectiles/SimpleProjectiles/SimpleProjectile.cpp
@@ -40,7 +40,7 @@ void SimpleProjectile::Cycle() {
     if (_partition.isPartitionPlayed(_timer->getCurrent()))
         this->Destroy();
     auto pos = _partition.GetCurrentSegment(_timer->getCurrent())->getLocationVector().GetTweened();
-    _eventManager->Emit(ProjectilePositionChangedMessage::EventType, new ProjectilePositionChangedMessage(_emitterId, pos), this);
+    _eventManager->Emit(ProjectilePositionChangedMessage::EventType, new ProjectilePositionChangedMessage(_emitterId, pos, true), this);
 }
 
 SimpleProjectile::~SimpleProjectile() {

--- a/SharedLibs/Entities/Projectiles/SimpleProjectiles/SimpleProjectile.cpp
+++ b/SharedLibs/Entities/Projectiles/SimpleProjectiles/SimpleProjectile.cpp
@@ -40,7 +40,7 @@ void SimpleProjectile::Cycle() {
     if (_partition.isPartitionPlayed(_timer->getCurrent()))
         this->Destroy();
     auto pos = _partition.GetCurrentSegment(_timer->getCurrent())->getLocationVector().GetTweened();
-    _eventManager->Emit(ProjectilePositionChangedMessage::EventType, new ProjectilePositionChangedMessage(_id, pos), this);
+    _eventManager->Emit(ProjectilePositionChangedMessage::EventType, new ProjectilePositionChangedMessage(_emitterId, pos), this);
 }
 
 SimpleProjectile::~SimpleProjectile() {

--- a/SharedLibs/Entities/Projectiles/SimpleProjectiles/SimpleProjectile.cpp
+++ b/SharedLibs/Entities/Projectiles/SimpleProjectiles/SimpleProjectile.cpp
@@ -8,10 +8,26 @@
 #include <PartitionSystem/Tween/Curve/EaseInOutCurve.hpp>
 #include <PartitionSystem/Tween/Curve/EaseOutCurve.hpp>
 #include <iostream>
+#include <Messages/ProjectilePositionChangedMessage.hpp>
 
-SimpleProjectile::SimpleProjectile(const std::initializer_list<void *> init) : SimpleProjectile(*GetParamFromInitializerList<uint16_t *>(init, 0), GetParamFromInitializerList<Timer*>(init, 1), GetParamFromInitializerList<RType::EventManager*>(init, 2), *GetParamFromInitializerList<TimeRef*>(init, 3), *GetParamFromInitializerList<vec2<float>*>(init, 4)) { }
+SimpleProjectile::SimpleProjectile(const std::initializer_list<void *> init) :
+        SimpleProjectile(*GetParamFromInitializerList<uint16_t *>(init, 0),
+                         GetParamFromInitializerList<Timer*>(init, 1),
+                         GetParamFromInitializerList<RType::EventManager*>(init, 2),
+                         *GetParamFromInitializerList<TimeRef*>(init, 3),
+                         *GetParamFromInitializerList<vec2<float>*>(init, 4),
+                         GetParamFromInitializerList<std::initializer_list<void *>*>(init, 5))
+{
 
-SimpleProjectile::SimpleProjectile(uint16_t id, Timer *timer, RType::EventManager *eventManager, TimeRef const &timeRef, vec2<float> const &startPosition) : Entity(id, timer, eventManager) {
+}
+
+SimpleProjectile::SimpleProjectile(uint16_t id,
+                                   Timer *timer,
+                                   RType::EventManager *eventManager,
+                                   TimeRef const &timeRef,
+                                   vec2<float> const &startPosition,
+                                   const std::initializer_list<void *> *params) : Entity(id, timer, eventManager) {
+    _emitterId = *GetParamFromInitializerList<uint16_t *>(*params, 0);
     _partition = EntityPartitionBuilder(timer, timeRef, startPosition).AddSegment(
                     PartitionSegmentBuilder()
                             .Begins(timeRef)
@@ -23,6 +39,8 @@ SimpleProjectile::SimpleProjectile(uint16_t id, Timer *timer, RType::EventManage
 void SimpleProjectile::Cycle() {
     if (_partition.isPartitionPlayed(_timer->getCurrent()))
         this->Destroy();
+    auto pos = _partition.GetCurrentSegment(_timer->getCurrent())->getLocationVector().GetTweened();
+    _eventManager->Emit(ProjectilePositionChangedMessage::EventType, new ProjectilePositionChangedMessage(_id, pos), this);
 }
 
 SimpleProjectile::~SimpleProjectile() {

--- a/SharedLibs/Entities/Projectiles/SimpleProjectiles/SimpleProjectile.hpp
+++ b/SharedLibs/Entities/Projectiles/SimpleProjectiles/SimpleProjectile.hpp
@@ -8,19 +8,18 @@
 #include <PartitionSystem/EntityPartition.hpp>
 #include <EventDispatcher/EventManager.hpp>
 #include <Base.h>
+#include <Entities/Entity.hpp>
 
 class SimpleProjectile : public Entity {
 protected:
-    Timer *_timer = nullptr;
     EntityPartition _partition = EntityPartition(_timer);
-    RType::EventManager *_eventManager;
 
 public:
     virtual ~SimpleProjectile();
 
 public:
     SimpleProjectile(const std::initializer_list<void *> init);
-    SimpleProjectile(Timer *, RType::EventManager *, TimeRef const &, vec2<float> const &);
+    SimpleProjectile(uint16_t, Timer *, RType::EventManager *, TimeRef const &, vec2<float> const &);
 
     void Cycle() override;
 };

--- a/SharedLibs/Entities/Projectiles/SimpleProjectiles/SimpleProjectile.hpp
+++ b/SharedLibs/Entities/Projectiles/SimpleProjectiles/SimpleProjectile.hpp
@@ -13,13 +13,14 @@
 class SimpleProjectile : public Entity {
 protected:
     EntityPartition _partition = EntityPartition(_timer);
+    uint16_t _emitterId = 0;
 
 public:
     virtual ~SimpleProjectile();
 
 public:
     SimpleProjectile(const std::initializer_list<void *> init);
-    SimpleProjectile(uint16_t, Timer *, RType::EventManager *, TimeRef const &, vec2<float> const &);
+    SimpleProjectile(uint16_t, Timer *, RType::EventManager *, TimeRef const &, vec2<float> const &, const std::initializer_list<void *> *);
 
     void Cycle() override;
 };


### PR DESCRIPTION
- [x] Les entités ont maintenant un `ID`
- [x] Les entités meurent quand elles sont touchés par des projectiles ennemis.
- [x] Le constructeur des `Entity` externes acceptent maintenant une `std::initializer_list` contenant des paramètres arbitraires (par exemple on passe au nouveau projectile l'`ID` de l'entité qui l'a tiré).