### PR TITLE
Réparer les incohérences raw pointers -- smart pointers.

### DIFF
--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -8,7 +8,7 @@ include_directories(Includes Interfaces)
 IF (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 ELSE()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror -Wuninitialized -Winit-self -Wno-unused-parameter -Wno-unused-private-field")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror -Wuninitialized -Winit-self -Weffc++ -Wno-unused-parameter -Wno-unused-private-field")
 ENDIF()
 
 include_directories(SYSTEM "../SFML/include/")

--- a/Client/src/GameContext/ClientEntityPool.cpp
+++ b/Client/src/GameContext/ClientEntityPool.cpp
@@ -27,6 +27,6 @@ ClientEntityPool::ClientEntityPool(const std::shared_ptr<Timer> &timer) : Entity
 void ClientEntityPool::AddEntity(std::string const &entityName, uint16_t id, vec2<float> const &initialPos, TimeRef const &startTime, std::initializer_list<void *> *params) {
     auto now = startTime;
     auto pos = initialPos;
-    ManagedExternalInstance<Entity> entity(ExternalClassFactoryLoader::Instance->GetInstanceOf<Entity>("", "Drawable" + entityName, { &id, _timer.get(), _eventManager, &now, &pos, params }, "createDrawable", "destroyDrawable"));
+    ManagedExternalInstance<Entity> entity(ExternalClassFactoryLoader::Instance->GetInstanceOf<Entity>("", "Drawable" + entityName, { &id, &_timer, &_eventManager, &now, &pos, params }, "createDrawable", "destroyDrawable"));
     _pool.push_back(entity);
 }

--- a/Server/CMakeLists.txt
+++ b/Server/CMakeLists.txt
@@ -14,7 +14,7 @@ set(SERVER_SOURCE_FILES
 IF (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 ELSE()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror -Wuninitialized -Winit-self -Wno-unused-parameter -Wno-unused-private-field")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror -Wuninitialized -Winit-self -Weffc++ -Wno-unused-parameter -Wno-unused-private-field")
 ENDIF()
 
 add_executable(R_Type_Server ${SERVER_SOURCE_FILES})

--- a/Shared/CMakeLists.txt
+++ b/Shared/CMakeLists.txt
@@ -41,9 +41,11 @@ set(SHARED_SOURCE_FILES
 
         Include/IService.hpp
         Include/vec2.hpp
-        Include/Messages/FireProjectileMessage.hpp
 
-        Include/Json/Json.hpp Include/Messages/ProjectilePositionChangedMessage.hpp)
+        Include/Messages/FireProjectileMessage.hpp
+        Include/Messages/ProjectilePositionChangedMessage.hpp
+
+        Include/Json/Json.hpp)
 
 include_directories(Libs/Interfaces
         ../SFML/include
@@ -56,7 +58,7 @@ IF (MSVC)
     set(LIB_SOCKET ws2_32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 ELSE()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror -Wuninitialized -Winit-self -Wno-unused-parameter -Wno-unused-private-field")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror -Wuninitialized -Winit-self -Weffc++ -Wno-unused-parameter -Wno-unused-private-field")
 ENDIF()
 
 add_library(RTypeShared STATIC ${SHARED_SOURCE_FILES})

--- a/Shared/EntityPool/EntityPool.cpp
+++ b/Shared/EntityPool/EntityPool.cpp
@@ -8,7 +8,7 @@
 void EntityPool::AddEntity(std::string const &entityName, uint16_t id, vec2<float> const &initialPos, TimeRef const &timeRef, std::initializer_list<void *> *params) {
     auto now = timeRef;
     auto pos = initialPos;
-    ManagedExternalInstance<Entity> entity(ExternalClassFactoryLoader::Instance->GetInstanceOf<Entity>("", entityName, { &id, _timer.get() , _eventManager, &now, &pos, params }, "create", "destroy"));
+    ManagedExternalInstance<Entity> entity(ExternalClassFactoryLoader::Instance->GetInstanceOf<Entity>("", entityName, { &id, &_timer , &_eventManager, &now, &pos, params }, "create", "destroy"));
     _pool.push_back(entity);
 }
 
@@ -20,7 +20,7 @@ EntityPool::EntityPool(std::shared_ptr<Timer> const &timer) : _timer(timer) {
     });
 }
 
-const RType::EventManager *EntityPool::getEventManager() const {
+const std::shared_ptr<RType::EventManager> &EntityPool::getEventManager() const {
     return _eventManager;
 }
 

--- a/Shared/Include/Entities/Entity.hpp
+++ b/Shared/Include/Entities/Entity.hpp
@@ -14,14 +14,14 @@
 class Entity {
 protected:
     uint16_t _id;
-    Timer *_timer = nullptr;
-    RType::EventManager *_eventManager;
+    std::shared_ptr<Timer> _timer;
+    std::shared_ptr<RType::EventManager> _eventManager;
 
     std::vector<Trait> _traits = std::vector<Trait>();
 public:
     virtual ~Entity() { }
 
-    Entity(uint16_t _id, Timer *timer, RType::EventManager *eventMgr) : _id(_id), _timer(timer), _eventManager(eventMgr) {}
+    Entity(uint16_t _id, std::shared_ptr<Timer> timer, std::shared_ptr<RType::EventManager> eventMgr) : _id(_id), _timer(timer), _eventManager(eventMgr) {}
 
     virtual bool ImplementTrait(Trait trait) {
         for(auto x : _traits)

--- a/Shared/Include/EntityPool/EntityPool.hpp
+++ b/Shared/Include/EntityPool/EntityPool.hpp
@@ -19,8 +19,8 @@
 class EntityPool {
 protected:
     std::vector<ManagedExternalInstance<Entity>> _pool = std::vector<ManagedExternalInstance<Entity>>();
-    RType::EventManager *_eventManager = new RType::EventManager();
-    RType::EventListener _eventListener = RType::EventListener(_eventManager);
+    std::shared_ptr<RType::EventManager> _eventManager = std::make_shared<RType::EventManager>();
+    RType::EventListener _eventListener = RType::EventListener(_eventManager.get());
     std::shared_ptr<Timer> _timer;
 
 public:
@@ -35,7 +35,7 @@ public:
     void LoadPartition(std::string const &);
 
 public:
-    const RType::EventManager *getEventManager() const;
+    const std::shared_ptr<RType::EventManager> &getEventManager() const;
 
 private:
     void SpawnProjectile(FireProjectileMessage const &, const uint16_t emitterId);

--- a/Shared/Include/EntityPool/EntityPool.hpp
+++ b/Shared/Include/EntityPool/EntityPool.hpp
@@ -20,7 +20,7 @@ class EntityPool {
 protected:
     std::vector<ManagedExternalInstance<Entity>> _pool = std::vector<ManagedExternalInstance<Entity>>();
     std::shared_ptr<RType::EventManager> _eventManager = std::make_shared<RType::EventManager>();
-    RType::EventListener _eventListener = RType::EventListener(_eventManager.get());
+    RType::EventListener _eventListener = RType::EventListener(_eventManager);
     std::shared_ptr<Timer> _timer;
 
 public:

--- a/Shared/Include/EventDispatcher/EventListener.hpp
+++ b/Shared/Include/EventDispatcher/EventListener.hpp
@@ -15,11 +15,11 @@ namespace RType {
         typedef std::map<RType::Event, std::vector<std::function<void(void *, IMessage *message)>>> callback_map;
 
     private:
-        RType::EventManager *_eventManager = nullptr;
+        std::shared_ptr<RType::EventManager> _eventManager = nullptr;
         std::shared_ptr<callback_map> _callbacks;
 
     public:
-        EventListener(RType::EventManager *eventManager) :
+        EventListener(std::shared_ptr<RType::EventManager> eventManager) :
                 _eventManager(eventManager),
                 _callbacks(std::shared_ptr<callback_map>(new callback_map())) {
             _eventManager->AddListener(_callbacks);

--- a/Shared/Include/PartitionSystem/EntityPartition.hpp
+++ b/Shared/Include/PartitionSystem/EntityPartition.hpp
@@ -13,7 +13,7 @@ private:
     std::vector<PartitionSegment> _segments;
 
 public:
-    EntityPartition(Timer *timer) : _segments(std::vector<PartitionSegment>()) {};
+    EntityPartition(std::shared_ptr<Timer> timer) : _segments(std::vector<PartitionSegment>()) {};
 
 public:
     EntityPartition &AddSegment(PartitionSegment const &segment){

--- a/Shared/Include/PartitionSystem/EntityPartitionBuilder.hpp
+++ b/Shared/Include/PartitionSystem/EntityPartitionBuilder.hpp
@@ -12,12 +12,12 @@
 class EntityPartitionBuilder {
 private:
     std::vector<PartitionSegmentBuilder> _segments;
-    Timer *_timer;
+    std::shared_ptr<Timer> _timer;
     TimeRef _startTime;
     vec2<float> _initialPosition;
 
 public:
-    EntityPartitionBuilder(Timer *timer, TimeRef const &startTime, vec2<float> const &initialPos) : _segments(), _timer(timer), _startTime(startTime), _initialPosition(initialPos) {}
+    EntityPartitionBuilder(std::shared_ptr<Timer> timer, TimeRef const &startTime, vec2<float> const &initialPos) : _segments(), _timer(timer), _startTime(startTime), _initialPosition(initialPos) {}
 
 public:
     EntityPartitionBuilder &AddSegment(PartitionSegmentBuilder &segment){

--- a/Shared/Include/PartitionSystem/PartitionSegmentBuilder.hpp
+++ b/Shared/Include/PartitionSystem/PartitionSegmentBuilder.hpp
@@ -83,7 +83,7 @@ public:
         return *this;
     }
 
-    PartitionSegment Build(Timer *timer){
+    PartitionSegment Build(std::shared_ptr<Timer> timer){
         if (_curvingOption == nullptr)
             _curvingOption = new LinearCurve();
         return PartitionSegment(Tween<vec2<float>>(timer, _startValue, _start, _endValue,

--- a/Shared/Include/PartitionSystem/PartitionSegmentBuilder.hpp
+++ b/Shared/Include/PartitionSystem/PartitionSegmentBuilder.hpp
@@ -13,7 +13,7 @@
 
 class PartitionSegmentBuilder {
 private:
-    ITweeningCurve *_curvingOption = nullptr;
+    std::shared_ptr<ITweeningCurve> _curvingOption = nullptr;
 
     TimeRef _start = TimeRef();
     std::chrono::milliseconds _duration = std::chrono::milliseconds();
@@ -64,7 +64,7 @@ public:
         return *this;
     }
 
-    PartitionSegmentBuilder &WithCurving(ITweeningCurve *curve){
+    PartitionSegmentBuilder &WithCurving(std::shared_ptr<ITweeningCurve> &curve){
         _curvingOption = curve;
         return *this;
     }
@@ -85,14 +85,14 @@ public:
 
     PartitionSegment Build(std::shared_ptr<Timer> timer){
         if (_curvingOption == nullptr)
-            _curvingOption = new LinearCurve();
+            _curvingOption = std::make_shared<LinearCurve>();
         return PartitionSegment(Tween<vec2<float>>(timer, _startValue, _start, _endValue,
                                                    TimeRef(_start.getMilliseconds() + _duration),
                                                    _curvingOption),
                                 _fireRate, _projectileType);
     }
 
-    ITweeningCurve *getCurvingOption() const{
+    std::shared_ptr<ITweeningCurve> getCurvingOption() const{
         return _curvingOption;
     }
 

--- a/Shared/Include/PartitionSystem/Tween/Tween.hpp
+++ b/Shared/Include/PartitionSystem/Tween/Tween.hpp
@@ -15,7 +15,7 @@ class Tween {
 
 private:
     std::shared_ptr<Timer> _timer = nullptr;
-    ITweeningCurve *_curvingOption;
+    std::shared_ptr<ITweeningCurve> _curvingOption;
 
     TweenInnerType _startValue;
     TweenInnerType _endValue;
@@ -33,11 +33,11 @@ public:
                                                                 _startValue(startValue), _endValue(endValue), _start(start), _end(end),
                                                                 _delta(_endValue - _startValue), _maxValue(std::numeric_limits<TweenInnerType>::max()){
         static_assert(std::is_base_of<ITweeningCurve, TweeningCurve>::value, "TweeningCurve must be a descendant of ITweeningCurve");
-        _curvingOption = new TweeningCurve();
+        _curvingOption = std::shared_ptr<TweeningCurve>(new TweeningCurve());
     }
 
     Tween(std::shared_ptr<Timer> timer, TweenInnerType const &startValue, TimeRef const &start,
-         TweenInnerType const &endValue, TimeRef const &end, ITweeningCurve *curve) : _timer(timer),_curvingOption(curve),
+         TweenInnerType const &endValue, TimeRef const &end, std::shared_ptr<ITweeningCurve> curve) : _timer(timer),_curvingOption(curve),
                                                                _startValue(startValue), _endValue(endValue), _start(start), _end(end),
                                                                _delta(_endValue - _startValue), _maxValue(std::numeric_limits<TweenInnerType>::max()){ }
 
@@ -61,7 +61,7 @@ public:
         return timeRef <= _end && timeRef >= _start;
     }
 
-    const ITweeningCurve *getCurvingOption() const {
+    const std::shared_ptr<ITweeningCurve> getCurvingOption() const {
         return _curvingOption;
     }
 

--- a/Shared/Include/PartitionSystem/Tween/Tween.hpp
+++ b/Shared/Include/PartitionSystem/Tween/Tween.hpp
@@ -14,7 +14,7 @@ template <typename TweenInnerType>
 class Tween {
 
 private:
-    Timer *_timer = nullptr;
+    std::shared_ptr<Timer> _timer = nullptr;
     ITweeningCurve *_curvingOption;
 
     TweenInnerType _startValue;
@@ -28,7 +28,7 @@ private:
 
 public:
     template <class TweeningCurve>
-    Tween(Timer *timer, TweenInnerType const &startValue, TimeRef const &start,
+    Tween(std::shared_ptr<Timer> timer, TweenInnerType const &startValue, TimeRef const &start,
           TweenInnerType const &endValue, TimeRef const &end) : _timer(timer), _curvingOption(nullptr),
                                                                 _startValue(startValue), _endValue(endValue), _start(start), _end(end),
                                                                 _delta(_endValue - _startValue), _maxValue(std::numeric_limits<TweenInnerType>::max()){
@@ -36,7 +36,7 @@ public:
         _curvingOption = new TweeningCurve();
     }
 
-    Tween(Timer *timer, TweenInnerType const &startValue, TimeRef const &start,
+    Tween(std::shared_ptr<Timer> timer, TweenInnerType const &startValue, TimeRef const &start,
          TweenInnerType const &endValue, TimeRef const &end, ITweeningCurve *curve) : _timer(timer),_curvingOption(curve),
                                                                _startValue(startValue), _endValue(endValue), _start(start), _end(end),
                                                                _delta(_endValue - _startValue), _maxValue(std::numeric_limits<TweenInnerType>::max()){ }

--- a/Shared/UnitTests/EventDispatcher/EventDispatcherTest.cpp
+++ b/Shared/UnitTests/EventDispatcher/EventDispatcherTest.cpp
@@ -18,7 +18,7 @@ TEST(Tests_EventDispatcher, EmitEventWithSubscribeAndUnsunbscribe) {
 
     RType::Bullet bulletEntity;
     std::shared_ptr<RType::EventManager> e = std::shared_ptr<RType::EventManager>(new RType::EventManager);
-    RType::EventListener listener(e.get());
+    RType::EventListener listener(e);
 
     listener.Subscribe<RType::Bullet, void>(RType::BULLET_POS_CHANGE, [](RType::Bullet *bullet, void *) {
         bullet->a = 42;

--- a/Shared/UnitTests/PartitionSystem/EntityPartition.cpp
+++ b/Shared/UnitTests/PartitionSystem/EntityPartition.cpp
@@ -7,7 +7,7 @@
 #include <PartitionSystem/EntityPartitionBuilder.hpp>
 
 TEST(EntityPartionTest, PlayPlayValidEntityPartition) {
-    auto timer = new Timer(std::chrono::steady_clock::now());
+    auto timer = std::shared_ptr<Timer>(new Timer(std::chrono::steady_clock::now()));
 
     //Create our entity partition
     auto partition = EntityPartitionBuilder(timer, timer->getCurrent(), vec2<float>(0, 0))

--- a/Shared/UnitTests/Tween/LinearTween.cpp
+++ b/Shared/UnitTests/Tween/LinearTween.cpp
@@ -8,7 +8,7 @@
 #include <PartitionSystem/Tween/Curve/LinearCurve.hpp>
 
 TEST(Tests_LinearTween, CreateTweenStartingFromCurrentTime) {
-    auto timer = new Timer(std::chrono::steady_clock::now());
+    auto timer = std::shared_ptr<Timer>(new Timer(std::chrono::steady_clock::now()));
 
     Tween<int> tween(timer, 0, timer->getStart(), 100, timer->getCurrent().GetRelative(std::chrono::milliseconds(1000)), new LinearCurve());
     std::this_thread::sleep_for(std::chrono::milliseconds(250));
@@ -25,7 +25,7 @@ TEST(Tests_LinearTween, CreateTweenStartingFromFutureTime) {
     auto dtn = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::milliseconds(500));
     auto future = nowClock + dtn;
 
-    auto timer = new Timer(future);
+    auto timer = std::shared_ptr<Timer>(new Timer(future));
 
     Tween<int> tween(timer, 0, timer->getStart(), 100, timer->getStart().GetRelative(std::chrono::milliseconds(1000)), new LinearCurve());
     std::this_thread::sleep_for(std::chrono::milliseconds(490));

--- a/Shared/UnitTests/Tween/LinearTween.cpp
+++ b/Shared/UnitTests/Tween/LinearTween.cpp
@@ -10,7 +10,7 @@
 TEST(Tests_LinearTween, CreateTweenStartingFromCurrentTime) {
     auto timer = std::shared_ptr<Timer>(new Timer(std::chrono::steady_clock::now()));
 
-    Tween<int> tween(timer, 0, timer->getStart(), 100, timer->getCurrent().GetRelative(std::chrono::milliseconds(1000)), new LinearCurve());
+    Tween<int> tween(timer, 0, timer->getStart(), 100, timer->getCurrent().GetRelative(std::chrono::milliseconds(1000)), std::make_shared<LinearCurve>());
     std::this_thread::sleep_for(std::chrono::milliseconds(250));
     int now = tween.GetTweened();
     ASSERT_EQ(now > 20 && now < 40, true) << "Tween should be 50 but is " << now;
@@ -27,7 +27,7 @@ TEST(Tests_LinearTween, CreateTweenStartingFromFutureTime) {
 
     auto timer = std::shared_ptr<Timer>(new Timer(future));
 
-    Tween<int> tween(timer, 0, timer->getStart(), 100, timer->getStart().GetRelative(std::chrono::milliseconds(1000)), new LinearCurve());
+    Tween<int> tween(timer, 0, timer->getStart(), 100, timer->getStart().GetRelative(std::chrono::milliseconds(1000)), std::make_shared<LinearCurve>());
     std::this_thread::sleep_for(std::chrono::milliseconds(490));
     int now = tween.GetTweened();
     ASSERT_EQ(now < 100, true) << "Tween should be 0 but is " << now;

--- a/SharedLibs/Entities/Monsters/DummyMonster/CMakeLists.txt
+++ b/SharedLibs/Entities/Monsters/DummyMonster/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.6.2)
 IF (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 ELSE()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror -Wuninitialized -Winit-self -Wno-unused-parameter")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror -Wuninitialized -Winit-self -Weffc++ -Wno-unused-parameter")
 ENDIF()
 
 add_library(DummyMonster SHARED

--- a/SharedLibs/Entities/Monsters/DummyMonster/DummyMonster.cpp
+++ b/SharedLibs/Entities/Monsters/DummyMonster/DummyMonster.cpp
@@ -8,13 +8,13 @@
 #include <Messages/ProjectilePositionChangedMessage.hpp>
 #include <iostream>
 
-DummyMonster::DummyMonster(const std::initializer_list<void *> init) : DummyMonster(*GetParamFromInitializerList<uint16_t *>(init, 0), GetParamFromInitializerList<Timer*>(init, 1), GetParamFromInitializerList<RType::EventManager*>(init, 2), *GetParamFromInitializerList<TimeRef*>(init, 3), *GetParamFromInitializerList<vec2<float>*>(init, 4)) { }
+DummyMonster::DummyMonster(const std::initializer_list<void *> init) : DummyMonster(*GetParamFromInitializerList<uint16_t *>(init, 0), *GetParamFromInitializerList<std::shared_ptr<Timer>*>(init, 1), *GetParamFromInitializerList<std::shared_ptr<RType::EventManager>*>(init, 2), *GetParamFromInitializerList<TimeRef*>(init, 3), *GetParamFromInitializerList<vec2<float>*>(init, 4)) { }
 
-DummyMonster::DummyMonster(uint16_t id, Timer *timer, RType::EventManager *eventManager, TimeRef const &timeRef, vec2<float> const &startPosition) :
+DummyMonster::DummyMonster(uint16_t id, std::shared_ptr<Timer> timer, std::shared_ptr<RType::EventManager> eventManager, TimeRef const &timeRef, vec2<float> const &startPosition) :
         Entity(id, timer, eventManager)
 {
-    _eventListener = std::unique_ptr<RType::EventListener>(new RType::EventListener(eventManager));
-    _partition = EntityPartitionBuilder(timer, timeRef, startPosition).AddSegment(
+    _eventListener = std::unique_ptr<RType::EventListener>(new RType::EventListener(eventManager.get()));
+    _partition = EntityPartitionBuilder(timer.get(), timeRef, startPosition).AddSegment(
                     PartitionSegmentBuilder()
                             .Begins(timeRef)
                             .For(std::chrono::seconds(10000))

--- a/SharedLibs/Entities/Monsters/DummyMonster/DummyMonster.cpp
+++ b/SharedLibs/Entities/Monsters/DummyMonster/DummyMonster.cpp
@@ -13,7 +13,7 @@ DummyMonster::DummyMonster(const std::initializer_list<void *> init) : DummyMons
 DummyMonster::DummyMonster(uint16_t id, std::shared_ptr<Timer> timer, std::shared_ptr<RType::EventManager> eventManager, TimeRef const &timeRef, vec2<float> const &startPosition) :
         Entity(id, timer, eventManager)
 {
-    _eventListener = std::unique_ptr<RType::EventListener>(new RType::EventListener(eventManager.get()));
+    _eventListener = std::unique_ptr<RType::EventListener>(new RType::EventListener(eventManager));
     _partition = EntityPartitionBuilder(timer.get(), timeRef, startPosition).AddSegment(
                     PartitionSegmentBuilder()
                             .Begins(timeRef)

--- a/SharedLibs/Entities/Monsters/DummyMonster/DummyMonster.cpp
+++ b/SharedLibs/Entities/Monsters/DummyMonster/DummyMonster.cpp
@@ -14,7 +14,7 @@ DummyMonster::DummyMonster(uint16_t id, std::shared_ptr<Timer> timer, std::share
         Entity(id, timer, eventManager)
 {
     _eventListener = std::unique_ptr<RType::EventListener>(new RType::EventListener(eventManager));
-    _partition = EntityPartitionBuilder(timer.get(), timeRef, startPosition).AddSegment(
+    _partition = EntityPartitionBuilder(timer, timeRef, startPosition).AddSegment(
                     PartitionSegmentBuilder()
                             .Begins(timeRef)
                             .For(std::chrono::seconds(10000))

--- a/SharedLibs/Entities/Monsters/DummyMonster/DummyMonster.cpp
+++ b/SharedLibs/Entities/Monsters/DummyMonster/DummyMonster.cpp
@@ -11,9 +11,8 @@
 DummyMonster::DummyMonster(const std::initializer_list<void *> init) : DummyMonster(*GetParamFromInitializerList<uint16_t *>(init, 0), *GetParamFromInitializerList<std::shared_ptr<Timer>*>(init, 1), *GetParamFromInitializerList<std::shared_ptr<RType::EventManager>*>(init, 2), *GetParamFromInitializerList<TimeRef*>(init, 3), *GetParamFromInitializerList<vec2<float>*>(init, 4)) { }
 
 DummyMonster::DummyMonster(uint16_t id, std::shared_ptr<Timer> timer, std::shared_ptr<RType::EventManager> eventManager, TimeRef const &timeRef, vec2<float> const &startPosition) :
-        Entity(id, timer, eventManager)
+        Entity(id, timer, eventManager), _eventListener(std::unique_ptr<RType::EventListener>(new RType::EventListener(eventManager)))
 {
-    _eventListener = std::unique_ptr<RType::EventListener>(new RType::EventListener(eventManager));
     _partition = EntityPartitionBuilder(timer, timeRef, startPosition).AddSegment(
                     PartitionSegmentBuilder()
                             .Begins(timeRef)

--- a/SharedLibs/Entities/Monsters/DummyMonster/DummyMonster.hpp
+++ b/SharedLibs/Entities/Monsters/DummyMonster/DummyMonster.hpp
@@ -15,12 +15,12 @@
 
 class DummyMonster : public Entity {
 protected:
-    EntityPartition _partition = EntityPartition(_timer);
+    EntityPartition _partition = EntityPartition(_timer.get());
     std::unique_ptr<RType::EventListener> _eventListener;
 
 public:
     DummyMonster(const std::initializer_list<void *> init);
-    DummyMonster(uint16_t, Timer *, RType::EventManager *, TimeRef const &, vec2<float> const &);
+    DummyMonster(uint16_t, std::shared_ptr<Timer>, std::shared_ptr<RType::EventManager>, TimeRef const &, vec2<float> const &);
 
     void Cycle() override;
 };

--- a/SharedLibs/Entities/Monsters/DummyMonster/DummyMonster.hpp
+++ b/SharedLibs/Entities/Monsters/DummyMonster/DummyMonster.hpp
@@ -15,7 +15,7 @@
 
 class DummyMonster : public Entity {
 protected:
-    EntityPartition _partition = EntityPartition(_timer.get());
+    EntityPartition _partition = EntityPartition(_timer);
     std::unique_ptr<RType::EventListener> _eventListener;
 
 public:

--- a/SharedLibs/Entities/Player/CMakeLists.txt
+++ b/SharedLibs/Entities/Player/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.6.2)
 IF (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 ELSE()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror -Wuninitialized -Winit-self -Wno-unused-parameter")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror -Wuninitialized -Winit-self -Weffc++ -Wno-unused-parameter")
 ENDIF()
 
 add_library(Player SHARED

--- a/SharedLibs/Entities/Player/Player.cpp
+++ b/SharedLibs/Entities/Player/Player.cpp
@@ -5,9 +5,9 @@
 #include "Player.hpp"
 #include <Messages/FireProjectileMessage.hpp>
 
-Player::Player(const std::initializer_list<void *> init) : Player(*GetParamFromInitializerList<uint16_t  *>(init, 0), GetParamFromInitializerList<Timer*>(init, 1), GetParamFromInitializerList<RType::EventManager*>(init, 2), *GetParamFromInitializerList<TimeRef*>(init, 3), *GetParamFromInitializerList<vec2<float>*>(init, 4)) { }
+Player::Player(const std::initializer_list<void *> init) : Player(*GetParamFromInitializerList<uint16_t  *>(init, 0), *GetParamFromInitializerList<std::shared_ptr<Timer>*>(init, 1), *GetParamFromInitializerList<std::shared_ptr<RType::EventManager>*>(init, 2), *GetParamFromInitializerList<TimeRef*>(init, 3), *GetParamFromInitializerList<vec2<float>*>(init, 4)) { }
 
-Player::Player(uint16_t id, Timer *timer, RType::EventManager *eventManager, TimeRef const &timeRef, vec2<float> const &startPosition) : Entity(id, timer, eventManager) {
+Player::Player(uint16_t id, std::shared_ptr<Timer> timer, std::shared_ptr<RType::EventManager> eventManager, TimeRef const &timeRef, vec2<float> const &startPosition) : Entity(id, timer, eventManager) {
 
 }
 

--- a/SharedLibs/Entities/Player/Player.hpp
+++ b/SharedLibs/Entities/Player/Player.hpp
@@ -16,7 +16,7 @@ protected:
 
 public:
     Player(const std::initializer_list<void *> init);
-    Player(uint16_t, Timer *, RType::EventManager *, TimeRef const &, vec2<float> const &);
+    Player(uint16_t, std::shared_ptr<Timer>, std::shared_ptr<RType::EventManager>, TimeRef const &, vec2<float> const &);
 
     void Cycle() override;
 };

--- a/SharedLibs/Entities/Projectiles/SimpleProjectiles/CMakeLists.txt
+++ b/SharedLibs/Entities/Projectiles/SimpleProjectiles/CMakeLists.txt
@@ -4,7 +4,7 @@ project (DrawableSimpleProjectile)
 IF (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 ELSE()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror -Wuninitialized -Winit-self -Wno-unused-parameter")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror -Wuninitialized -Winit-self -Weffc++ -Wno-unused-parameter")
 ENDIF()
 
 include_directories(../../../../Shared/Libs/Interfaces ../../../../Shared/Include ../../.. ../../../../SFML/include)

--- a/SharedLibs/Entities/Projectiles/SimpleProjectiles/SimpleProjectile.cpp
+++ b/SharedLibs/Entities/Projectiles/SimpleProjectiles/SimpleProjectile.cpp
@@ -12,8 +12,8 @@
 
 SimpleProjectile::SimpleProjectile(const std::initializer_list<void *> init) :
         SimpleProjectile(*GetParamFromInitializerList<uint16_t *>(init, 0),
-                         GetParamFromInitializerList<Timer*>(init, 1),
-                         GetParamFromInitializerList<RType::EventManager*>(init, 2),
+                         *GetParamFromInitializerList<std::shared_ptr<Timer>*>(init, 1),
+                         *GetParamFromInitializerList<std::shared_ptr<RType::EventManager>*>(init, 2),
                          *GetParamFromInitializerList<TimeRef*>(init, 3),
                          *GetParamFromInitializerList<vec2<float>*>(init, 4),
                          GetParamFromInitializerList<std::initializer_list<void *>*>(init, 5))
@@ -22,13 +22,13 @@ SimpleProjectile::SimpleProjectile(const std::initializer_list<void *> init) :
 }
 
 SimpleProjectile::SimpleProjectile(uint16_t id,
-                                   Timer *timer,
-                                   RType::EventManager *eventManager,
+                                   std::shared_ptr<Timer> timer,
+                                   std::shared_ptr<RType::EventManager> eventManager,
                                    TimeRef const &timeRef,
                                    vec2<float> const &startPosition,
                                    const std::initializer_list<void *> *params) : Entity(id, timer, eventManager) {
     _emitterId = *GetParamFromInitializerList<uint16_t *>(*params, 0);
-    _partition = EntityPartitionBuilder(timer, timeRef, startPosition).AddSegment(
+    _partition = EntityPartitionBuilder(timer.get(), timeRef, startPosition).AddSegment(
                     PartitionSegmentBuilder()
                             .Begins(timeRef)
                             .For(std::chrono::seconds(2))

--- a/SharedLibs/Entities/Projectiles/SimpleProjectiles/SimpleProjectile.cpp
+++ b/SharedLibs/Entities/Projectiles/SimpleProjectiles/SimpleProjectile.cpp
@@ -28,7 +28,7 @@ SimpleProjectile::SimpleProjectile(uint16_t id,
                                    vec2<float> const &startPosition,
                                    const std::initializer_list<void *> *params) : Entity(id, timer, eventManager) {
     _emitterId = *GetParamFromInitializerList<uint16_t *>(*params, 0);
-    _partition = EntityPartitionBuilder(timer.get(), timeRef, startPosition).AddSegment(
+    _partition = EntityPartitionBuilder(timer, timeRef, startPosition).AddSegment(
                     PartitionSegmentBuilder()
                             .Begins(timeRef)
                             .For(std::chrono::seconds(2))

--- a/SharedLibs/Entities/Projectiles/SimpleProjectiles/SimpleProjectile.hpp
+++ b/SharedLibs/Entities/Projectiles/SimpleProjectiles/SimpleProjectile.hpp
@@ -12,7 +12,7 @@
 
 class SimpleProjectile : public Entity {
 protected:
-    EntityPartition _partition = EntityPartition(_timer);
+    EntityPartition _partition = EntityPartition(_timer.get());
     uint16_t _emitterId = 0;
 
 public:
@@ -20,7 +20,7 @@ public:
 
 public:
     SimpleProjectile(const std::initializer_list<void *> init);
-    SimpleProjectile(uint16_t, Timer *, RType::EventManager *, TimeRef const &, vec2<float> const &, const std::initializer_list<void *> *);
+    SimpleProjectile(uint16_t, std::shared_ptr<Timer>, std::shared_ptr<RType::EventManager>, TimeRef const &, vec2<float> const &, const std::initializer_list<void *> *);
 
     void Cycle() override;
 };

--- a/SharedLibs/Entities/Projectiles/SimpleProjectiles/SimpleProjectile.hpp
+++ b/SharedLibs/Entities/Projectiles/SimpleProjectiles/SimpleProjectile.hpp
@@ -12,7 +12,7 @@
 
 class SimpleProjectile : public Entity {
 protected:
-    EntityPartition _partition = EntityPartition(_timer.get());
+    EntityPartition _partition = EntityPartition(_timer);
     uint16_t _emitterId = 0;
 
 public:

--- a/SharedLibs/Interfaces/IDrawable.hpp
+++ b/SharedLibs/Interfaces/IDrawable.hpp
@@ -6,7 +6,11 @@
 #define R_TYPE_IDRAWABLE_HPP
 
 #include <vec2.hpp>
-#include <SFML/Graphics.hpp>
+
+#pragma GCC diagnostic ignored "-Weffc++"
+#include <SFML/Graphics.hpp> //SFML is not Weffc++ compliant
+#pragma GCC diagnostic pop
+
 #include <TextureBag.hpp>
 
 class IDrawable {

--- a/SharedLibs/Interfaces/IDrawable.hpp
+++ b/SharedLibs/Interfaces/IDrawable.hpp
@@ -7,6 +7,7 @@
 
 #include <vec2.hpp>
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Weffc++"
 #include <SFML/Graphics.hpp> //SFML is not Weffc++ compliant
 #pragma GCC diagnostic pop


### PR DESCRIPTION
- [x] Il ne reste plus aucun `raw pointer`sur l'intégralité du projet.
- [x] Tous les projets compilent maintenant avec `-Weffc++` (y compris les lib externes).